### PR TITLE
Fix ffmpeg-kit depenedency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'com.google.android.exoplayer:exoplayer-dash:2.14.2'
     implementation 'com.google.android.exoplayer:exoplayer-ui:2.14.2'
    // implementation 'com.github.yangjie10930:EpMedia:v1.0.1'
-    implementation 'com.github.tanersener:ffmpeg-kit:v4.4'
+    implementation 'com.arthenica:ffmpeg-kit-full:4.4.LTS'
     implementation 'org.florescu.android.rangeseekbar:rangeseekbar-library:0.3.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'


### PR DESCRIPTION
Sadly the jitpack.io repo is not properly build and misses the `*.so` files